### PR TITLE
Using build numbers for incremental scripts

### DIFF
--- a/.github/workflows/expo-build-number.sh
+++ b/.github/workflows/expo-build-number.sh
@@ -1,0 +1,39 @@
+#!/bin/bash --no-profile --norc
+
+#
+# This script will update the versions in the app.json file.
+#
+# For publishing files in testflight we need the "next"-branch to set the ios buildnumber to the
+# <version-number>d<number> where the number is from 0-255. This script looks for the commits since
+# the last version number to calculate this number. In the "master"-branch it will just use the
+# buildNumber.
+#
+# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/plist/info/CFBundleVersion
+#
+# It will also set the versionCode for Android to the number of commits in the branch.
+#
+
+VERSION_CODE=`git rev-list --count HEAD`
+CURRENT=`npx json -f app.json expo.version`
+
+if [ -z $1 ]; then
+  BUILD_NUMBER="${CURRENT}"
+else
+  BUILD=1
+  while IFS= read -r COMMIT; do
+    COMMIT_VERSION=`git show ${COMMIT}:app.json | npx json "expo.version"`
+    if [ $COMMIT_VERSION != $CURRENT ]; then
+      break
+    fi
+    ((BUILD++))
+  done < <(git --no-pager log -254 --pretty=format:"%H" app.json)
+  BUILD_NUMBER="${CURRENT}${1}${BUILD}"
+fi
+
+updateAppJson () {
+  echo $1
+  npx json -I -f app.json -e "this.$1" > /dev/null 2>&1
+}
+
+updateAppJson "expo.ios.buildNumber='${BUILD_NUMBER}'"
+updateAppJson "expo.android.versionCode=${VERSION_CODE}"

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -35,11 +35,13 @@ jobs:
     - name: Publish & build with Expo channel "default"
       if: endsWith(github.ref, '/master')
       run: | 
+        ./.github/workflows/expo-build-number.sh
         npx expo build:android -t app-bundle --non-interactive --release-channel default
         npx expo build:ios -t archive --release-channel default
 
     - name: Publish & build with Expo channel "next"
       if: endsWith(github.ref, '/next')
       run: |
+        ./.github/workflows/expo-build-number.sh d
         npx expo build:android -t app-bundle --non-interactive --release-channel next
         npx expo build:ios -t archive --release-channel next

--- a/app.json
+++ b/app.json
@@ -28,7 +28,6 @@
     },
     "android": {
       "package": "org.consento.mobile",
-      "versionCode": 2,
       "permissions": [
         "CAMERA"
       ]
@@ -38,7 +37,6 @@
       "infoPlist": {
         "NSCameraUsageDescription": "This lets you take photos and scan QR codes."
       },
-      "buildNumber": "1.0.1",
       "icon": "./assets/icon/logo-with-bg@16x.png"
     },
     "notification": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -24242,6 +24242,12 @@
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
       "integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
     },
+    "json": {
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/json/-/json-9.0.6.tgz",
+      "integrity": "sha1-eXLCpaSKQmeNsnMMfCxO5uTiRYU=",
+      "dev": true
+    },
     "json-buffer": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.0.tgz",

--- a/package.json
+++ b/package.json
@@ -79,6 +79,7 @@
     "jest-enzyme": "^7.1.2",
     "jest-expo": "^36.0.1",
     "jetifier": "^1.6.5",
+    "json": "^9.0.6",
     "nicer": "^1.0.0",
     "ts-jest": "^25.2.0",
     "typescript": "^3.7.5",


### PR DESCRIPTION
This PR adds an automatic development version to the ios build for the next branch and a property versionCode for android based on the git history.