### PR TITLE
Fixing depth issue with build scripts.

### DIFF
--- a/.github/workflows/expo-build-number.sh
+++ b/.github/workflows/expo-build-number.sh
@@ -13,7 +13,7 @@
 # It will also set the versionCode for Android to the number of commits in the branch.
 #
 
-VERSION_CODE=`git rev-list --count HEAD`
+VERSION_CODE=`git rev-list --count origin/$(git rev-parse --abbrev-ref HEAD)`
 CURRENT=`npx json -f app.json expo.version`
 
 if [ -z $1 ]; then

--- a/.github/workflows/expo.yml
+++ b/.github/workflows/expo.yml
@@ -15,8 +15,15 @@ jobs:
         node-version: [12.x]
 
     steps:
-    - name: Checkout project repository
+    - name: Checkout project repository - != next
+      if: "!endsWith(github.ref, '/next')"
       uses: actions/checkout@v2
+
+    - name: Checkout project repository - == next
+      if: endsWith(github.ref, '/next')
+      uses: actions/checkout@v2
+      with:
+        fetch-depth: 255
 
     - name: Setup kernel for react native, increase watchers
       run: echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p


### PR DESCRIPTION
- The android version code is now determined by the remote tracking branch length (which means that it will work without cloning the entire repo)
- For the "next" build we set the fetch-depth to 255 which means that we will have at least the past 255 commits to work from.