### PR TITLE
Fixes iOS version numbering

### DIFF
--- a/.github/workflows/expo-build-number.sh
+++ b/.github/workflows/expo-build-number.sh
@@ -3,12 +3,13 @@
 #
 # This script will update the versions in the app.json file.
 #
-# For publishing files in testflight we need the "next"-branch to set the ios buildnumber to the
-# <version-number>d<number> where the number is from 0-255. This script looks for the commits since
-# the last version number to calculate this number. In the "master"-branch it will just use the
-# buildNumber.
+# For publishing with ios we need unique builds which all need a unique semver id. As a build is not
+# necessarily equal to an id, and we might want to test a version before publishing it, we specify
+# for ios that the version has 3 extra digits that represent the number of commits since the previous
+# version number. e.g. 3 commits after 1.0.2 becomes 1.0.2003. This is only computed if a command line
+# argument is passed in. Without the argument (for the master branch) we use 000 -> 1.0.2000
 #
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html#//apple_ref/doc/plist/info/CFBundleVersion
+# https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleversion
 #
 # It will also set the versionCode for Android to the number of commits in the branch.
 #
@@ -17,7 +18,7 @@ VERSION_CODE=`git rev-list --count HEAD`
 CURRENT=`npx json -f app.json expo.version`
 
 if [ -z $1 ]; then
-  BUILD_NUMBER="${CURRENT}"
+  BUILD=0
 else
   BUILD=1
   while IFS= read -r COMMIT; do
@@ -26,8 +27,7 @@ else
       break
     fi
     ((BUILD++))
-  done < <(git --no-pager log -254 --pretty=format:"%H" app.json)
-  BUILD_NUMBER="${CURRENT}${1}${BUILD}"
+  done < <(git --no-pager log -999 --pretty=format:"%H" app.json)
 fi
 
 updateAppJson () {
@@ -35,5 +35,5 @@ updateAppJson () {
   npx json -I -f app.json -e "this.$1" > /dev/null 2>&1
 }
 
-updateAppJson "expo.ios.buildNumber='${BUILD_NUMBER}'"
+updateAppJson "expo.ios.buildNumber='${CURRENT}$(printf "%03d\n" $BUILD)'"
 updateAppJson "expo.android.versionCode=${VERSION_CODE}"

--- a/.github/workflows/expo-build-number.sh
+++ b/.github/workflows/expo-build-number.sh
@@ -14,7 +14,7 @@
 # It will also set the versionCode for Android to the number of commits in the branch.
 #
 
-VERSION_CODE=`git rev-list --count origin/$(git rev-parse --abbrev-ref HEAD)`
+VERSION_CODE=`git fetch && git rev-list --count origin/$(git rev-parse --abbrev-ref HEAD)`
 CURRENT=`npx json -f app.json expo.version`
 
 if [ -z $1 ]; then


### PR DESCRIPTION
The documentation used to create the the ios versioning 1.0.1b234 was outdated/wrong/not-working. This PR uses creates ios version numbers as 1.0.1234 which should work for publication on the AppStore